### PR TITLE
Docker: Running outside Docker

### DIFF
--- a/Mothership-server.rst
+++ b/Mothership-server.rst
@@ -67,6 +67,8 @@ following command:
 
 Then TLS will be disabled on both the API and uplink. You can choose whether you want to disable TLS on the Mothership API or the uplink (the connection between Mothership and the IncludeOS instances) or both.
 
+.. _mothership-server-options:
+
 Server options
 ~~~~~~~~~~~~~~
 
@@ -84,8 +86,40 @@ Notable options are::
       --serverauth string            server auth method (default "none")
       --serverport string            port number (default "8080")
       --verboselogging               <bool, optional> verbose logging
-      --dockeroptions                Options to use when building in docker inside Mothership
+      --dockeroptions                Options to use when building in Docker inside Mothership
       --config                       Manually provided path to config file
+
+
+.. _mothership-in-docker:
+
+Running in Docker
+~~~~~~~~~~~~~~~~~
+
+Mothership comes with a Dockerfile which includes necessary dependencies.
+
+First build and the run the Mothership Docker container::
+
+  $ docker build -t mothership .
+  $ docker run \
+    --name mothership \
+    -p 8080:8080 \
+    -p 9090:9090 \
+    -v $PWD/config_files:/home/ubuntu/mothership/config_files \
+    -v mothership_storage:/home/ubuntu/mothership/runtime_files \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    mothership serve
+
+The options used are::
+
+    First are the Docker options:
+        --name mothership                   Give Docker container name
+        -p 8080:8080                        Forward port 8080
+        -p 9090:9090                        Forward port 9090
+        -v $PWD/config_files:/home/ubuntu/mothership/config_files   Bind-mount config_files folder into mothership
+        -v mothership_storage:/home/ubuntu/mothership/runtime_files Mount named volume into mothership
+        -v /var/run/docker.sock:/var/run/docker.sock  Mount hosts Docker process into container
+    Then the mothership options:
+        mothership serve                    Start mothership server
 
 If you want to run the Mothership in Docker but want to change some of the default settings mentioned above, you just
 add :code:`serve` at the end, followed by the Mothership options you want to change or add:
@@ -98,6 +132,12 @@ add :code:`serve` at the end, followed by the Mothership options you want to cha
     -v /var/run/docker.sock:/var/run/docker.sock \
     mothership serve --verboselogging
 
+Docker in Docker
+^^^^^^^^^^^^^^^^
+
+Building IncludeOS images is performed by a Docker container. This is used to deliver a preconfigured build environment and makes it more convenient to release new IncludeOS versions. In order to allow for the Mothership to use Docker commands the servers Docker socket is mounted into the Docker container: ``-v /var/run/docker.sock:/var/run/docker.sock``.
+
+.. note:: If you are experiencing problems with permissions for the mounted resources you might need to launch the Docker container with ``--dockeroptions "--privileged"`` as a Mothership option as well.
 
 .. _bobs-and-builders:
 

--- a/Quick-start.rst
+++ b/Quick-start.rst
@@ -5,8 +5,14 @@ Quick start
 
 Dependencies
 ------------
-- `Docker <https://docs.docker.com/install/>`__
-- `htpasswd <https://httpd.apache.org/docs/2.4/programs/htpasswd.html>`__
+
+============================================================================= =======================================================
+Tool                                                                           Usage
+============================================================================= =======================================================
+`docker <https://docs.docker.com/install>`__                                   Building IncludeOS
+`qemu-img <https://linux.die.net/man/1/qemu-img>`__                            Converting disk
+`htpasswd <https://httpd.apache.org/docs/2.4/programs/htpasswd.html>`__        Creating users. Often provided by the *apache-utils* package
+============================================================================= =======================================================
 
 1. Clone Git repository
 -----------------------
@@ -37,33 +43,15 @@ For instructions on how to generate a self-signed certificate for testing see: :
 
 .. _build_launch_mothership:
 
-4. Build and launch Mothership
+4. Launch Mothership
 ------------------------------
-First build then then run mothership using docker::
+Launch Mothership with the command::
 
-    $ docker build -t mothership .
-    $ docker run \
-        --name mothership \
-        -p 8080:8080 \
-        -p 9090:9090 \
-        -v $PWD/config_files:/home/ubuntu/mothership/config_files \
-        -v mothership_storage:/home/ubuntu/mothership/runtime_files \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        mothership serve
+  $ ./<mothership-binary> serve
 
-The options used are::
+To see all launch options run ``./<mothership-binary> serve -h`` or see :ref:`mothership-server-options`.
+To run Mothership inside a Docker container see :ref:`mothership-in-docker`.
 
-    First are the docker options:
-        --name mothership                   Give docker container name
-        -p 8080:8080                        Forward port 8080
-        -p 9090:9090                        Forward port 9090
-        -v $PWD/config_files:/home/ubuntu/mothership/config_files   Bind-mount config_files folder into mothership
-        -v mothership_storage:/home/ubuntu/mothership/runtime_files Mount named volume into mothership
-        -v /var/run/docker.sock:/var/run/docker.sock  Mount hosts docker process into container
-    Then the mothership options:
-        mothership serve                    Start mothership server
-
-.. note:: If you are experiencing problems with permissions for the mounted resources you might need to launch the docker container with ``--privileged``. On systems like RedHat Enterprise Linux that use SELinux this might be necessary. This will need to be sent to the inside as well by using ``--dockeroptions "--privileged"`` as a Mothership option as well. 
 
 This will launch the mothership server. Make sure there are no errors in the launch output and the following lines indicate that basic auth and TLS are properly configured::
 
@@ -85,6 +73,6 @@ Command-line interface
 
 Using the CLI the following command will give you information about the running instances::
 
-    $ ./mothership-linux-amd64 --username <username> --password <password> instances
+    $ ./<mothership-binary> --username <username> --password <password> instances
     Instances:
     Alias  Status  ID  Image Tag  Launched

--- a/Upgrading.rst
+++ b/Upgrading.rst
@@ -3,13 +3,16 @@
 Upgrading Mothership
 =======================================
 
-When a new version of Mothership is available you will have to rebuild your Mothership docker image to go to the new version.
-
-Keeping all data intact
+Keeping all data
 -----------------------
-All the runtime data (images, NaCls, uplinks) used by Mothership is kept in the folder called ``runtime_files``. The :ref:`Quick-start` mounted this directory to a docker volume named ``mothership_storage``. If this volume is kept intact all the files will be used by the new version of Mothership.
+When upgrading to a new version of Mothership all configuration and runtime files are kept in two directories:
 
-The other set of data used is kept in the folder ``config_files``. This is mounted from the host and will therefore be intact as well.
+  ``config_files``
+    Contains all users and passwords, any TLS certificates and configuration files.
+  ``runtime_files``
+    All the runtime data (images, NaCls, uplinks, logs) used by Mothership.
+
+When stopping the Mothership make sure these two directories are kept intact.
 
 Pull changes
 ------------
@@ -22,19 +25,8 @@ or if you were using a specific ssh key::
 
     $ ssh-agent bash -c 'ssh-add mothership_beta.key; git pull'
 
-Build new Mothership
---------------------
-To build the new Mothership perform a docker build::
-
-    $ docker build -t mothership .
-
-Stop running Mothership
------------------------
-To stop and remove the running mothership simply perform::
-
-    $ docker stop mothership
-    $ docker rm mothership
-
 Start the new Mothership
 ------------------------
 To start Mothership with the new version use the same command as referenced in :ref:`Launch command <build_launch_mothership>`.
+
+If Docker is in use make sure the Docker container is rebuilt before launching the new Mothership. See :ref:`mothership-in-docker`


### PR DESCRIPTION
I moved all Docker documentation to a separate header under `Mothership Server`. The quick start guide now only has a link to the Docker documentation.

I also updated the `upgrading` guide to make sense when not using Docker. 

Added `qemu-img` as a dependency. 